### PR TITLE
Include requirements.txt into sphinx_doc

### DIFF
--- a/sphinx_doc/pre_requisites.rst
+++ b/sphinx_doc/pre_requisites.rst
@@ -2,26 +2,10 @@ Pre-requisites
 ===============
 Python modules
 --------------
-Described in requirements.txt
 
-* Django==1.8.12
-* Markdown==2.6.6
-* celery==3.1.23
-* cssmin==0.2.0
-* django-pipeline==1.6.8
-* django-simple-captcha==0.4.5
-* djangorestframework==2.3.4
-* django-rest-swagger==0.3.5
-* docutils==0.12
-* jsmin==2.0.11
-* pillow==2.2.2
-* psycopg2==2.6
-* pycrypto==2.6.1
-* python-memcached==1.57
-* python-social-auth==0.2.16
-* requests-oauthlib==0.6.1
-* wsgiref 
-* django-suit==0.2.18
+Described in ``requirements.txt``:
+
+.. literalinclude:: ../requirements.txt
 
 Service-side pre-requisites
 ---------------------------


### PR DESCRIPTION
For issue #23. I made the content of pre-requisites of Python modules in sphinx_doc directly from the `requirements.txt`. Therefore, we only need to maintain the `requirements.txt` and don't need to update sphinx_doc manually. 