### PR TITLE
FIxed issue #23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.8.12
 Markdown==2.6.6
-celery==3.1.13
+celery==3.1.23
 cssmin==0.2.0
 django-pipeline==1.6.8
 django-simple-captcha==0.4.5
@@ -15,3 +15,4 @@ python-memcached==1.57
 python-social-auth==0.2.16
 requests-oauthlib==0.6.1
 wsgiref==0.1.2
+django-suit==0.2.18


### PR DESCRIPTION
I have tested that `celery 3.1.23` works fine. After this update, the `requirements_new.txt` can be removed safely.