### PR TITLE
Setup script for downloading blast binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,8 @@ py2.7/
 
 # Sphinx build docs
 sphinx_doc/_build/
+
+# blast binaries
+blast/bin_linux/
+blast/bin_win/
+blast/bin_mac/

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ requests-oauthlib==0.6.1
 wsgiref==0.1.2
 selenium==3.5.0
 django-suit==0.2.18
+six>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+from os import remove
+from os.path import dirname, abspath, join, exists
+from sys import platform
+from shutil import rmtree, move
+import tarfile
+from six.moves import urllib
+
+PROJECT_ROOT = dirname(abspath(__file__))
+
+bin_name = 'bin_linux'
+if platform == 'win32':
+    bin_name = 'bin_win'
+elif platform == 'darwin':
+    bin_name = 'bin_mac'
+
+bin_path = join(PROJECT_ROOT, 'blast/', bin_name + '/')
+# delete old files if exist
+if exists(bin_path):
+    rmtree(bin_path)
+
+local_file_path = join(PROJECT_ROOT, 'blast.tar.gz')
+if exists(local_file_path):
+    remove(local_file_path)
+
+extracted_blast_path = join(PROJECT_ROOT, 'ncbi-blast-2.2.29+')
+if exists(extracted_blast_path):
+    rmtree(extracted_blast_path)
+# download the blast binary
+if platform == 'win32':
+    urllib.request.urlretrieve(
+        ('ftp://ftp.ncbi.nlm.nih.gov/blast/executables/'
+            'blast+/2.2.29/ncbi-blast-2.2.29+-x64-win64.tar.gz'),
+        local_file_path)
+elif platform == 'darwin':
+    urllib.request.urlretrieve(
+        ('ftp://ftp.ncbi.nlm.nih.gov/blast/executables/'
+            'blast+/2.2.29/ncbi-blast-2.2.29+-universal-macosx.tar.gz'),
+        local_file_path)
+else:  # for linux
+    urllib.request.urlretrieve(
+        ('ftp://ftp.ncbi.nlm.nih.gov/blast/executables/'
+            'blast+/2.2.29/ncbi-blast-2.2.29+-x64-linux.tar.gz'),
+        local_file_path)
+# extract tar.gz file
+tar = tarfile.open(local_file_path, "r:gz")
+tar.extractall()
+tar.close()
+# move bin file to specific path
+move(join(extracted_blast_path, 'bin'), bin_path)

--- a/sphinx_doc/app_conf.rst
+++ b/sphinx_doc/app_conf.rst
@@ -6,9 +6,6 @@ Introduction
 
 I5K BLAST Tutorial is on https://i5k.nal.usda.gov/content/blast-tutorial
 
-Install & Configuration
-~~~~~~~~~~~~~~~~~~~~~~~
-Install `BLAST <http://blast.ncbi.nlm.nih.gov/Blast.cgi>`_ and append Blast_bin directory in environment variable ``PATH``.
 
 BLAST DB Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -18,11 +15,11 @@ There are five tables for creating BLAST DB and browsing in I5K-blast.
 
   * Display name should be scientific name.
   * Short name are used by system as a abbreviation.
-  * Descriptions and NCBI taxa ID are automatically filled. 
+  * Descriptions and NCBI taxa ID are automatically filled.
 
 .. image:: add_organism.png
 
-* Add Sequence types: 
+* Add Sequence types:
 
   * Used to classify BLAST DBs in distinct catagories.
   * Provide two kinds of molecule type for choosing, Nucleotide/Peptide.
@@ -36,7 +33,7 @@ There are five tables for creating BLAST DB and browsing in I5K-blast.
   * Type ``Title`` name. (showed in HMMER page)
   * Type ``Descriptions``.
   * Check ``is shown``, if not check, this database would show in HMMER page.
-  * Save 
+  * Save
 
 .. image:: add_blastdb.png
 
@@ -54,7 +51,7 @@ Install `HMMER <http://hmmer.org/>`_ and append HMMER_bin directory in evironmen
 
 HMMER DB Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
-Like Blast, HMMER databases must be configured then they could be searched. 
+Like Blast, HMMER databases must be configured then they could be searched.
 
 Go django admin page and click Hmmer on left-menubar. You need to create HMMER db instance (Hmmer dbs) for each fasta file.
 
@@ -63,7 +60,7 @@ Go django admin page and click Hmmer on left-menubar. You need to create HMMER d
 * Type ``Title`` name. (showed in HMMER page)
 * Type ``Descriptions``.
 * Check ``is shown``, if not check, this database would show in HMMER page.
-* Save 
+* Save
 
 .. image:: hmmer_add.png
 
@@ -120,4 +117,4 @@ Coonection to Drupal summit data function.
 
 WebApollo SSO
 -------------
-Complete introduction locate in Section 4. 
+Complete introduction locate in Section 4.

--- a/sphinx_doc/setup_guide_centos.rst
+++ b/sphinx_doc/setup_guide_centos.rst
@@ -3,19 +3,19 @@ Setup Guide (CentOS)
 
 This setup guide is for CentOS. It's tested in CentOS 6.7 and CentOS 7.2 with django 1.8.12
 
-Note: The following variables may be used in path names; substitute as appropriate:: 
+Note: The following variables may be used in path names; substitute as appropriate::
 
-   <user>      :  the name of the user doing a set up. 
+   <user>      :  the name of the user doing a set up.
    <user-home> :  the user's home directory, e.g., /home/<user>
    <git-home>  :  the directory containing the genomics-workspace, and `.git/` folder for `git` will be there.
 
-Project Applications 
+Project Applications
 --------------------
 
 Clone or refresh the genomics-workspace::
 
     git clone https://github.com/NAL-i5K/genomics-workspace
-    
+
     # Or if the  repository exists:
     cd <git-home>
     git fetch
@@ -26,56 +26,56 @@ Yum
 Generate metadata cache::
 
     yum makecache
-    
+
 Python
 ------------
 
 Install necessary packages::
 
     sudo yum -y groupinstall "Development tools"
-    sudo yum -y install zlib-devel bzip2-devel openssl-devel ncurses-devel sqlite-devel 
+    sudo yum -y install zlib-devel bzip2-devel openssl-devel ncurses-devel sqlite-devel
     sudo yum -y install readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel python-devel
 
 Install python 2.7.13 from source::
 
     cd <user-home>
-    wget http://www.python.org/ftp/python/2.7.8/Python-2.7.13.tar.xz  
+    wget http://www.python.org/ftp/python/2.7.8/Python-2.7.13.tar.xz
     tar -xf Python-2.7.13.tar.xz
-    
+
     # Configure as a shared library:
     cd Python-2.7.13
     ./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib"
 
     # Compile and install:
-    make  
+    make
     sudo make altinstall
-    
+
     # Update PATH:
     export PATH="/usr/local/bin:$PATH"
-    
+
     # Checking Python version (output should be: Python 2.7.13):
     python2.7 -V
 
     # Cleanup if desired:
     cd ..
     rm -rf Python-2.7.13.tar.xz Python-2.7.13
-    
+
 Install pip and virtualenv::
 
     wget https://bootstrap.pypa.io/ez_setup.py
     sudo /usr/local/bin/python2.7 ez_setup.py
-    
+
     wget https://bootstrap.pypa.io/get-pip.py
     sudo /usr/local/bin/python2.7 get-pip.py
-    
+
     sudo /usr/local/bin/pip2.7 install virtualenv
 
 Build a separate virtualenv::
 
     cd <git-home>
-    
+
     # Create a virtual environment called py2.7 and activate:
-    virtualenv py2.7 
+    virtualenv py2.7
     source py2.7/bin/activate
 
 
@@ -84,9 +84,9 @@ RabbitMQ
 
 Install RabbitMQ Server::
 
-    cd <user-home> 
+    cd <user-home>
 
-    # Install RHEL/CentOS 6.8 64-Bit Extra Packages for Enterprise Linux (Epel). 
+    # Install RHEL/CentOS 6.8 64-Bit Extra Packages for Enterprise Linux (Epel).
     # The 6.8 Epel caters for CentOS 6.*:
     wget https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
     sudo rpm -ivh epel-release-6-8.noarch.rpm
@@ -118,58 +118,58 @@ Install and activate memcached::
 
    sudo yum -y install memcached
 
-   # Set to start at boot time: 
-   sudo chkconfig memcached on 
+   # Set to start at boot time:
+   sudo chkconfig memcached on
 
 Database
 --------
 
 Install PostgreSQL::
 
-    # Add line to yum repository: 
+    # Add line to yum repository:
     echo 'exclude=postgresql*' | sudo tee -a /etc/yum.repos.d/CentOS-Base.repo
 
     # Install the PostgreSQL Global Development Group (PGDG) RPM file:
     sudo yum -y install http://yum.postgresql.org/9.5/redhat/rhel-6-x86_64/pgdg-centos95-9.5-2.noarch.rpm
-    
+
     # Install PostgreSQL 9.5:
     sudo yum -y install postgresql95-server postgresql95-contrib postgresql95-devel
-    
+
     # Initialize (uses default data directory: /var/lib/pgsql):
-    sudo service postgresql-9.5 initdb   
-    
+    sudo service postgresql-9.5 initdb
+
     # Startup at boot:
     sudo chkconfig postgresql-9.5 on
-    
+
     # Control:
     # sudo service postgresql-9.5 <command>
-    # 
+    #
     # where <command> can be:
-    #  
+    #
     #     start   : start the database.
     #     stop    : stop the database.
     #     restart : stop/start the database; used to read changes to core configuration files.
-    #     reload  : reload pg_hba.conf file while keeping database running. 
-    
+    #     reload  : reload pg_hba.conf file while keeping database running.
+
     # Start:
     sudo service postgresql-9.5 start
 
     #
     #  (To remove everything: sudo yum erase postgresql95*)
     #
-    
+
     # Create django database and user:
     sudo su - postgres
     psql
-    
+
     # At the prompt 'postgres=#' enter:
     create database django;
     create user django;
     grant all on database django to django;
-    
+
     # Connect to django database:
     \c django
-    
+
     # Create extension hstore:
     create extension hstore;
 
@@ -178,7 +178,7 @@ Install PostgreSQL::
     exit
 
     # Config in pg_hba.conf:
-    cd <git-home> 
+    cd <git-home>
     export PATH=/usr/pgsql-9.5/bin:$PATH
 
     # Restart:
@@ -192,7 +192,7 @@ Install additional Python packages::
 
     cd <git-home>
     pip install -r requirements.txt
- 
+
 
 Celery
 ------
@@ -200,8 +200,8 @@ Celery
 Configure the celery::
 
     # Copy files:
-    # 
-    # When using CentOS 7.* copy 
+    #
+    # When using CentOS 7.* copy
     # celeryd.sysconfig and celerybeat.sysconfig
     # to /etc/default instead.
     #
@@ -209,11 +209,11 @@ Configure the celery::
     sudo cp celerybeat /etc/init.d
     sudo cp celeryd.sysconfig /etc/sysconfig/celeryd
     sudo cp celerybeat.sysconfig /etc/sysconfig/celerybeat
-    
-    # Sudo edit '/etc/sysconfig/celeryd' as follows: 
+
+    # Sudo edit '/etc/sysconfig/celeryd' as follows:
     CELERYD_CHDIR="<git-home>"
     CELERYD_MULTI="<git-home>/py2.7/bin/celery multi"
-    
+
     # Sudo edit '/etc/sysconfig/celerybeat' as follows:
     CELERYBEAT_CHDIR="<git-home>"
     CELERY_BIN="<git-home>/py2.7/bin/celery"
@@ -224,7 +224,7 @@ Configure the celery::
 
 
 Migrate Schema to to PostgreSQL
-------------------------------- 
+-------------------------------
 
 Run migrate::
 
@@ -239,6 +239,15 @@ Run migrate::
     python manage.py makemigrations
     python manage.py migrate
 
+
+Install BLAST binary
+--------------------
+
+To instll blast binary::
+
+   python setup.py
+
+
 Start development server
 ------------------------
 
@@ -250,16 +259,16 @@ To run developement server::
 Apache (for production server)
 ------------------------------
 
-Please note: 
-It is essential that tcp port 80 be open in your system. Sometimes the firewall may deny access to it.   
+Please note:
+It is essential that tcp port 80 be open in your system. Sometimes the firewall may deny access to it.
 Check if iptables will drop input packets in the output of this command::
-  
-    sudo iptables -L 
+
+    sudo iptables -L
 
 If you see "INPUT" and "DROP" on the same line and no specific ACCEPT rule for tcp port 80
-chances are web traffic will be blocked. Ask your sysadmin to open tcp ports 80 and 443 for
-http and https. Alternatively, check this `iptables guide`_.   
-  .. _iptables guide: https://www.digitalocean.com/community/tutorials/how-to-set-up-a-basic-iptables-firewall-on-centos-6
+chances are web traffic will be blocked. Ask your sysadmin to open tcp ports 80 and 443 for http and https. Alternatively, check this `iptables guide`_.
+
+.. _iptables guide: https://www.digitalocean.com/community/tutorials/how-to-set-up-a-basic-iptables-firewall-on-centos-6
 
 Install Apache and related modules::
 
@@ -269,12 +278,12 @@ Give the system a fully qualified domain name (FQDN) if needed::
 
     # Find out the system IP addres with 'ifconfig'.
     # Assuming it is a VM created by Vagrant, this could be 10.0.2.15.
-    # Sudo edit '/etc/hosts' and add an address and domain name entry. 
+    # Sudo edit '/etc/hosts' and add an address and domain name entry.
     # For example:
     10.0.2.15  virtualCentOS.local virtualCentOS
 
     # Sudo edit the file /etc/httpd/conf/httpd.conf,
-    # and set the ServerName, for example: 
+    # and set the ServerName, for example:
     ServerName virtualCentOS.local:80
 
     # Set to start httpd at boot:
@@ -284,103 +293,124 @@ Give the system a fully qualified domain name (FQDN) if needed::
     sudo chkconfig --list httpd
 
     # Control:
-    #    sudo apachectl <command> 
+    #    sudo apachectl <command>
     # Where <command> can be:
     #     start         : Start httpd daemon.
     #     stop          : Stop httpd daemon.
-    #     restart       : Restart httpd daemon, start it if not running. 
+    #     restart       : Restart httpd daemon, start it if not running.
     #     status        : Brief status report.
-    #     graceful      : Restart without aborting open connections. 
+    #     graceful      : Restart without aborting open connections.
     #     graceful-stop : stop without aborting open connections.
     #
     # Start httpd daemon:
     sudo apachectl start
 
     # Test Apache:
-    # If all is well. This command should produce copious 
-    # HTML output and in the first few lines you should see: 
+    # If all is well. This command should produce copious
+    # HTML output and in the first few lines you should see:
     #   '<title>Apache HTTP Server Test Page powered by CentOS</title>'
     curl localhost
 
-    # You can also view the formatted Apache test page in your 
-    # browser, e.g., firefox http://<setup-machine-ip-address>  
+    # You can also view the formatted Apache test page in your
+    # browser, e.g., firefox http://<setup-machine-ip-address>
 
 
 ================================================================================
 
-This section documents the procedure to load organisms into the BLAST database. 
+This section documents the procedure to load organisms into the BLAST database.
 
-PRE-REQUISITES.  
+PRE-REQUISITES::
 
-    Storage: At least 32 GB of disk space. 
-    Memory:  At least 10 GB of memory in the system or VM. 
+    Storage: At least 32 GB of disk space.
+    Memory:  At least 10 GB of memory in the system or VM.
 
-To add organism to BLAST you need to download the relevant database files to the 
-application 'media' directory.  
+To add organism to BLAST you need to download the relevant database files to the
+application 'media' directory.
 
-If for example you want to copy the BLAST databases from gmod-dev, make sure 
-you have at least 32 GB of free disk space.  
+If for example you want to copy the BLAST databases from gmod-dev, make sure
+you have at least 32 GB of free disk space.
 
-Also, to run the tool that populates the sequence table you need to have at 
-least 10 GB of system or VM memory.  
+Also, to run the tool that populates the sequence table you need to have at
+least 10 GB of system or VM memory.
 
-    In your VM: 
+In your VM::
 
     cd <genomics-workspace-dir>/media
 
     rsync gmod-dev:/usr/local/i5k/media/blast/db/* .
 
-Organisms must be added one at a time using the Django app admin interface. 
+Organisms must be added one at a time using the Django app admin interface.
 
-You need access to a user id with admin privileges.  To do that you must alter 
-the Postgres database to add such privileges to a normal user. 
+You need access to a user id with admin privileges.  To do that you must alter
+the Postgres database to add such privileges to a normal user.
+
+::
 
     sudo su postgres
-    psql django 
+    psql django
 
-First clear any entries that prevent login. 
+First clear any entries that prevent login.
+
+::
 
     delete from  axes_accessattempt where username='<user_name';
 
 Set your id as superuser
 
+::
+
     update auth_user set is_staff = 't', is_active = 't' where username = '<user_name>';
 
-Now you should be able to login as admin and navigate to 
+Now you should be able to login as admin and navigate to
+
+::
 
     <your_system>/admin/blast
 
-And then to: 
+And then to:
 
-    Home » App » Organisms » Add organism 
+::
 
-For each organism: 
+    Home » App » Organisms » Add organism
+
+For each organism:
+
+::
 
     Enter the organism name in the field, 'Display Name'.
 
-    Click in the 'Short Name' and 'Description' fields to have them populated automatically. 
+    Click in the 'Short Name' and 'Description' fields to have them populated automatically.
 
     Enter the organism NCBI Taxonomy ID, and click 'SAVE'
 
-    Click on:  BLAST databases 'Add'  
+    Click on:  BLAST databases 'Add'
 
 
-Now you must add the databases that correspond to each organism, from those located in: 
+Now you must add the databases that correspond to each organism, from those located in:
+
+::
 
     <genomics-workspace-dir>/media/blast/db/*
 
-Navigate to: Home » BLAST » BLAST databases 
+Navigate to:
 
-On this screen for each organism: 
+::
 
-    1. From the top three dropdown lists, select the organism, the type of database type being 
-       loaded, and 'yes' for 'is_shown.' 
+   Home » BLAST » BLAST databases
 
-    2. Select the database files being loaded in the tabular list of database files.  
+On this screen for each organism:
 
-    3. From the dropdown list next to the 'Go' button, select, 'Populate the sequence table...' and click go.
+::
 
-    4. After a while, the three tick marks on each selected row should turn green.  
+    1. From the top three dropdown lists, select the organism, the type of database type being
+       loaded, and 'yes' for 'is_shown.'
+
+    2. Select the database files being loaded in the tabular list of database files.
+
+    3. From the dropdown list next to the 'Go' button, select, 'Populate the sequence table...'
+    and click go.
+
+    4. After a while, the three tick marks on each selected row should turn green.
 
 
 

--- a/sphinx_doc/setup_guide_macos.rst
+++ b/sphinx_doc/setup_guide_macos.rst
@@ -3,19 +3,19 @@ Setup Guide (MacOS)
 
 This setup guide is tested in MacOS Sierra (10.12.6) with django 1.8.12.
 
-Note: The following variables may be used in path names; substitute as appropriate:: 
+Note: The following variables may be used in path names; substitute as appropriate::
 
-   <user>      :  the name of the user doing a set up. 
+   <user>      :  the name of the user doing a set up.
    <user-home> :  the user's home directory, e.g., /home/<user>
    <git-home>  :  the directory containing the genomics-workspace, and `.git/` folder for `git` will be there.
 
-Project Applications 
+Project Applications
 --------------------
 
 Clone or refresh the genomics-workspace::
 
     git clone https://github.com/NAL-i5K/genomics-workspace
-    
+
     # Or if the  repository exists:
     cd <git-home>
     git fetch
@@ -35,12 +35,12 @@ Build a separate virtualenv::
 
     # Make root dir for virtualenv and cd into it:
     cd genomics-workspace
-    
+
     # Create a virtual environment called py2.7 and activate:
-    virtualenv py2.7 
+    virtualenv py2.7
     source py2.7/bin/activate
-    
-    
+
+
 RabbitMQ
 --------
 
@@ -67,15 +67,15 @@ Install PostgreSQL::
 
     brew postgres
     psql postgres
-    
+
     # At the prompt 'postgres=#' enter:
     create database django;
     create user django;
     grant all on database django to django;
-    
+
     # Connect to django database:
     \c django
-    
+
     # Create extension hstore:
     create extension hstore;
 
@@ -103,7 +103,7 @@ Configure celery::
     celery -A i5k beat --loglevel=info
 
 Migrate Schema to to PostgreSQL
-------------------------------- 
+-------------------------------
 
 Run migrate::
 
@@ -117,6 +117,15 @@ Run migrate::
     python manage.py makemigrations
     python manage.py migrate
 
+
+Install BLAST binary
+--------------------
+
+To instll blast binary::
+
+   python setup.py
+
+
 Start development server
 ------------------------
 
@@ -128,79 +137,100 @@ To run developement server::
 
 ================================================================================
 
-This section documents the procedure to load organisms into the BLAST database. 
+This section documents the procedure to load organisms into the BLAST database.
 
-PRE-REQUISITES.  
+PRE-REQUISITES.
 
-    Storage: At least 32 GB of disk space. 
-    Memory:  At least 10 GB of memory in the system or VM. 
+::
 
-To add organism to BLAST you need to download the relevant database files to the 
-application 'media' directory.  
+    Storage: At least 32 GB of disk space.
+    Memory:  At least 10 GB of memory in the system or VM.
 
-If for example you want to copy the BLAST databases from gmod-dev, make sure 
-you have at least 32 GB of free disk space.  
+To add organism to BLAST you need to download the relevant database files to the
+application 'media' directory.
 
-Also, to run the tool that populates the sequence table you need to have at 
-least 10 GB of system or VM memory.  
+If for example you want to copy the BLAST databases from gmod-dev, make sure
+you have at least 32 GB of free disk space.
 
-    In your VM: 
+Also, to run the tool that populates the sequence table you need to have at
+least 10 GB of system or VM memory.
+
+In your VM::
 
     cd <genomics-workspace-dir>/media
 
     rsync gmod-dev:/usr/local/i5k/media/blast/db/* .
 
-Organisms must be added one at a time using the Django app admin interface. 
+Organisms must be added one at a time using the Django app admin interface.
 
-You need access to a user id with admin privileges.  To do that you must alter 
-the Postgres database to add such privileges to a normal user. 
+You need access to a user id with admin privileges.  To do that you must alter
+the Postgres database to add such privileges to a normal user.
+
+::
 
     sudo su postgres
-    psql django 
+    psql django
 
-First clear any entries that prevent login. 
+First clear any entries that prevent login.
+
+::
 
     delete from  axes_accessattempt where username='<user_name';
 
 Set your id as superuser
 
+::
+
     update auth_user set is_staff = 't', is_active = 't' where username = '<user_name>';
 
-Now you should be able to login as admin and navigate to 
+Now you should be able to login as admin and navigate to
+
+::
 
     <your_system>/admin/blast
 
-And then to: 
+And then to:
 
-    Home » App » Organisms » Add organism 
+::
 
-For each organism: 
+    Home » App » Organisms » Add organism
+
+For each organism:
+
+::
 
     Enter the organism name in the field, 'Display Name'.
 
-    Click in the 'Short Name' and 'Description' fields to have them populated automatically. 
+    Click in the 'Short Name' and 'Description' fields to have them populated automatically.
 
     Enter the organism NCBI Taxonomy ID, and click 'SAVE'
 
-    Click on:  BLAST databases 'Add'  
+    Click on:  BLAST databases 'Add'
 
 
-Now you must add the databases that correspond to each organism, from those located in: 
+Now you must add the databases that correspond to each organism, from those located in:
+
+::
 
     <genomics-workspace-dir>/media/blast/db/*
 
-Navigate to: Home » BLAST » BLAST databases 
+Navigate to:
 
-On this screen for each organism: 
+::
 
-    1. From the top three dropdown lists, select the organism, the type of database type being 
-       loaded, and 'yes' for 'is_shown.' 
+   Home » BLAST » BLAST databases
 
-    2. Select the database files being loaded in the tabular list of database files.  
+On this screen for each organism::
 
-    3. From the dropdown list next to the 'Go' button, select, 'Populate the sequence table...' and click go.
+    1. From the top three dropdown lists, select the organism, the type of database type being
+       loaded, and 'yes' for 'is_shown.'
 
-    4. After a while, the three tick marks on each selected row should turn green.  
+    2. Select the database files being loaded in the tabular list of database files.
+
+    3. From the dropdown list next to the 'Go' button, select, 'Populate the sequence table...'
+    and click go.
+
+    4. After a while, the three tick marks on each selected row should turn green.
 
 
 


### PR DESCRIPTION
Use `python setup.py` to download the blast binary. The binary can be removed from repo now. The blast version is still `2.2.29` now.