### PR TITLE
fixed missing link to windows setup guide in sphinx_doc

### DIFF
--- a/sphinx_doc/setup_guide.rst
+++ b/sphinx_doc/setup_guide.rst
@@ -9,3 +9,4 @@ This is our introduction to this project.
 
    setup_guide_centos
    setup_guide_macos
+   setup_guide_win


### PR DESCRIPTION
I just found that the setup guide of Windows doesn't linked into our document. 