### PR TITLE
Make Travis automatically test building on MacOS and Linux at the same time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,45 @@
-language: python
-python: 2.7
+group: deprecated-2017Q4
+
 sudo: required
-services:
-  - rabbitmq
-  - memcached
-  - postgresql
+
+addons:
+  chrome: stable
+
+matrix:
+  include:
+  - os: linux
+    language: python
+    python: 2.7
+    services:
+    - rabbitmq
+    - memcached
+    - postgresql
+  - os: osx
+    language: generic
+    osx_image: xcode8.3
+  - os: osx
+    language: generic
+    osx_image: xcode7.3
 
 # command to install dependencies
 install:
-  - pip install -r requirements.txt
-  - pip install coveralls
-  - pip install codecov
-  - wget https://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip
-  - unzip chromedriver_linux64.zip
-  - export PATH=$PATH:$(pwd)
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install rabbitmq; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install memcached; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm -rf /usr/local/var/postgres; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then initdb /usr/local/var/postgres; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -D /usr/local/var/postgres start; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew services start rabbitmq; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew services start memcached; fi
+  - sudo pip2 install -r requirements.txt
+  - sudo pip2 install coveralls
+  - sudo pip2 install codecov
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://chromedriver.storage.googleapis.com/2.33/chromedriver_mac64.zip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then unzip chromedriver_mac64.zip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then unzip chromedriver_linux64.zip; fi
+  - export PATH=$PATH:$(pwd):/usr/local/sbin
 
 before_script:
   - psql -c 'create database django;' -U postgres
@@ -26,12 +52,12 @@ before_script:
   - sudo chmod 666 /var/log/django/django.log
   - sudo touch /var/log/django/i5k.log
   - sudo chmod 666 /var/log/django/i5k.log
-  - python manage.py makemigrations
-  - python manage.py migrate
-  - python setup.py
+  - sudo python2 manage.py makemigrations
+  - sudo python2 manage.py migrate
+  - sudo python2 setup.py
   - celery -A i5k worker --loglevel=info --concurrency=3 &
   - celery beat -A i5k --loglevel=info &
-  - python manage.py collectstatic --noinput
+  - sudo python2 manage.py collectstatic --noinput
 
 # command to run tests
 script:


### PR DESCRIPTION
By using matrix in .travis.yml, now we can test MacOS and Linux build at the same time.