### PR TITLE
Revert "Fix Field.to_representation() must be implemented issue for djangorestframework v3.0 up"

### DIFF
--- a/blast/serializers.py
+++ b/blast/serializers.py
@@ -31,7 +31,7 @@ class BlastDbSerializer(serializers.HyperlinkedModelSerializer):
 
 class SequenceSerializer(serializers.HyperlinkedModelSerializer):
     blast_db = serializers.HyperlinkedRelatedField(view_name='blast:blastdb-detail', lookup_field='title', read_only=True)
-    fasta_seq = serializers.ReadOnlyField()
+    fasta_seq = serializers.Field()
 
     class Meta:
         model = Sequence


### PR DESCRIPTION
Reverts NAL-i5K/genomics-workspace#94

We need to reconsider this, it looks like this change only fix development server but break the production server instead.