### PR TITLE
Remove option for analytics

### DIFF
--- a/app/context_processors.py
+++ b/app/context_processors.py
@@ -1,11 +1,7 @@
 from django.conf import settings
 
+
 def is_login_enabled(request):
     return {
         'isLoginEnabled': settings.LOGIN_ENABLED,
-    }
-
-def is_analytics_enabled(request):
-    return {
-        'isAnalyticsEnabled': settings.ANALYTICS_ENABLED,
     }

--- a/app/templates/app/layout.html
+++ b/app/templates/app/layout.html
@@ -12,9 +12,7 @@
     <link rel='stylesheet' type='text/css' href='https://fonts.googleapis.com/css?family=Inconsolata:400,700'>
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Tangerine">
     {% block head-scripts %}{% endblock %}
-    {% if isAnalyticsEnabled %}
-    <script type="text/javascript" src="{% static 'app/scripts/analytics.js' %}" async></script>
-    {% endif%}
+    {% javascript 'app-analytics' %}
 </head>
 
 <body class="padtop {% block bodyclass %}{% endblock %}">

--- a/i5k/settings.py
+++ b/i5k/settings.py
@@ -31,7 +31,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
                 'app.context_processors.is_login_enabled',
-                'app.context_processors.is_analytics_enabled',
             ],
         },
     },
@@ -433,6 +432,12 @@ PIPELINE = {
         },
     },
     'JAVASCRIPT': {
+        'app-analytics': {
+            'source_filenames': (
+                'app/scripts/analytics.js',
+            ),
+            'output_filename': 'app/scripts/app-analytics.min.js',
+        },
         'app-layout': {
             'source_filenames': (
                 'app/scripts/jquery-1.11.1.js',
@@ -519,7 +524,6 @@ except:
     HOSTNAME = 'localhost'
 
 LOGIN_ENABLED = False
-ANALYTICS_ENABLED = False
 
 # Use settings for production
 USE_PROD_SETTINGS = False


### PR DESCRIPTION
It seems to me that we should remove this option, because the default **analyics.js** is an empty file.