### PR TITLE
Pin amqp version to avoid run-time issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==1.11.11
 Markdown==2.6.6
+amqp==2.2.2
 celery==4.1.1
 cssmin==0.2.0
 django-pipeline==1.6.8


### PR DESCRIPTION
Starting from 7 hours ago (https://pypi.org/project/amqp/#history) The new amqp (2.3.0) will be installed through `pip install -r requirements.txt`, but this break our project. This patch will pin the version `amqp` we should use. It should fix recent failure of Travis build (https://travis-ci.org/NAL-i5K/genomics-workspace/builds/384417734).
