### PR TITLE
Fix blast serializer

### DIFF
--- a/blast/serializers.py
+++ b/blast/serializers.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-#from rest_framework.pagination import PaginationSerializer
 from django.contrib.auth.models import User
 from app.models import Organism
 from blast.models import SequenceType, BlastDb, Sequence, BlastQueryRecord
@@ -11,11 +10,13 @@ class OrganismSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Organism
 
+
 class SequenceTypeSerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='blast:sequencetype-detail', lookup_field='dataset_type')
 
     class Meta:
         model = SequenceType
+
 
 class BlastDbSerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='blast:blastdb-detail', lookup_field='title')
@@ -31,6 +32,7 @@ class BlastDbSerializer(serializers.HyperlinkedModelSerializer):
         model = BlastDb
         fields = ('url', 'organism', 'type', 'fasta_file', 'title', 'description', 'is_shown', 'fasta_file_exists', 'blast_db_files_exists', 'sequence_set_exists', 'db_ready', 'sequence_set', )
 
+
 class SequenceSerializer(serializers.HyperlinkedModelSerializer):
     blast_db = serializers.HyperlinkedRelatedField(view_name='blast:blastdb-detail', lookup_field='title', read_only=True)
     fasta_seq = serializers.ReadOnlyField()
@@ -39,9 +41,6 @@ class SequenceSerializer(serializers.HyperlinkedModelSerializer):
         model = Sequence
         fields = ('blast_db', 'id', 'length', 'seq_start_pos', 'seq_end_pos', 'modified_date', 'fasta_seq', )
 
-#class PaginatedSequenceSerializer(PaginationSerializer):
-    #class Meta:
-        #object_serializer_class = SequenceSerializer
 
 class BlastQueryRecordSerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='blast:blastqueryrecord-detail', lookup_field='task_id')
@@ -49,11 +48,13 @@ class BlastQueryRecordSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = BlastQueryRecord
 
+
 class UserSerializer(serializers.ModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='blast:user-detail', lookup_field='pk')
+
     class Meta:
         model = User
-        fields = ('id','url',)
+        fields = ('id', 'url',)
 
 
 class UserBlastQueryRecordSerializer(serializers.ModelSerializer):

--- a/blast/serializers.py
+++ b/blast/serializers.py
@@ -1,7 +1,9 @@
 from rest_framework import serializers
 #from rest_framework.pagination import PaginationSerializer
 from django.contrib.auth.models import User
-from .models import Organism, SequenceType, BlastDb, Sequence, BlastQueryRecord
+from app.models import Organism
+from blast.models import SequenceType, BlastDb, Sequence, BlastQueryRecord
+
 
 class OrganismSerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='blast:organism-detail', lookup_field='short_name')


### PR DESCRIPTION
This is a bug that blast's serializer used blast.organism  rather than app.organism. However, it seems to me that the bug didn't affect anything because this part of apis was't actually used. 