### PR TITLE
remove xcode 7.3 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ matrix:
   - os: osx
     language: generic
     osx_image: xcode8.3
-  - os: osx
-    language: generic
-    osx_image: xcode7.3
 
 # command to install dependencies
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ wsgiref==0.1.2
 django-suit==0.2.26
 six>=1.10.0
 django-axes==2.3.3
-requests==2.18.4 
+requests==2.20.0


### PR DESCRIPTION
It seems to me that xcode 7.3 (mac) instance of Travis CI frequently fails and we can safely remove it because we can still test it under xcode 8.3.