### PR TITLE
remove available genome browser option on nav bar

### DIFF
--- a/app/templates/app/layout.html
+++ b/app/templates/app/layout.html
@@ -26,10 +26,9 @@
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Tools<span class="caret"></span></a>
                         <ul class="dropdown-menu">
-                                <li><a href="{% url 'blast:create' %}">BLAST</a></li>
-                                <li><a href="{% url 'hmmer:create' %}">HMMER</a></li>
-                                <li><a href="{% url 'clustal:create' %}">CLUSTAL</a></li>
-                                <li><a href="https://i5k.nal.usda.gov/available-genome-browsers">JBrowse/Apollo</a></li>
+                            <li><a href="{% url 'blast:create' %}">BLAST</a></li>
+                            <li><a href="{% url 'hmmer:create' %}">HMMER</a></li>
+                            <li><a href="{% url 'clustal:create' %}">CLUSTAL</a></li>
                         </ul>
                     </li>
                 </ul>


### PR DESCRIPTION
It seems to me this should only present at our customzied version.